### PR TITLE
fix: avoid caching directory root in service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npx http-server -p 8000
 ```
 
 After the server starts, open `http://localhost:8000/index.html` in a modern browser.
+Make sure to visit the full path to `index.html` (not just `/`) because the service worker only caches that file.
 
 ## Building
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,6 @@
 const CACHE_NAME = 'lme-cache';
 
 const FILES_TO_CACHE = [
-  '/',
   'index.html',
   'manifest.json',
   'service-worker.js',


### PR DESCRIPTION
## Summary
- stop caching the web root `/` in the service worker
- clarify in the README that you should open the `index.html` file directly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404ebef5ec832e96f798c493ea4e00