### PR TITLE
Fix PPT month calculation

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ return `${d}-${m}-${y}`;
 
 function getSecondBusinessDay(year, month) {
 const holidays = lmeHolidays[year] || [];
-let date = new Date(year, month + 1, 1);
+let date = new Date(year, month, 1);
 let count = 0;
 while (count < 2) {
 const isoDate = date.toISOString().split('T')[0];


### PR DESCRIPTION
## Summary
- correct the start date in `getSecondBusinessDay` so PPT dates use the selected month

## Testing
- `node -e "global.window={};global.document={};global.navigator={};const fs=require('fs');eval(fs.readFileSync('main.js','utf8'));console.log(getSecondBusinessDay(2025,0));console.log(getSecondBusinessDay(2025,1));"`


------
https://chatgpt.com/codex/tasks/task_e_684051fe3588832eaa289627d29e3e8d