### PR TITLE
Update service worker caching list

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -4,9 +4,7 @@ const FILES_TO_CACHE = [
   'index.html',
   'main.js',
   'manifest.json',
-  'service-worker.js',
-  'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap',
-  'https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css'
+  'service-worker.js'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- cache only local files in service worker

## Testing
- `node puppeteer-test.js` (ensures service worker cache loads offline)

------
https://chatgpt.com/codex/tasks/task_e_6840521315e8832eaa05b5ba579a84f6