### PR TITLE
Dynamic year options

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
           </label>
           <label>Year:
             <select id="year1-0" class="border border-gray-300 rounded p-2 w-full">
-              <option>2025</option><option>2026</option>
+              <!-- Options populated via JavaScript -->
             </select>
           </label>
         </div>
@@ -65,7 +65,7 @@
           </label>
           <label>Year:
             <select id="year2-0" class="border border-gray-300 rounded p-2 w-full">
-              <option>2025</option><option>2026</option>
+              <!-- Options populated via JavaScript -->
             </select>
           </label>
           <label>Fixing Date: <input type="date" id="fixDate-0" class="border border-gray-300 rounded p-2" /></label>

--- a/main.js
+++ b/main.js
@@ -40,6 +40,19 @@ function getFixPpt(dateFix, year) {
 
 function capitalize(s) { return s.charAt(0).toUpperCase() + s.slice(1); }
 
+function populateYearOptions(selectId, start, count) {
+  const select = document.getElementById(selectId);
+  if (!select) return;
+  select.innerHTML = '';
+  for (let i = 0; i < count; i++) {
+    const year = start + i;
+    const opt = document.createElement('option');
+    opt.value = year;
+    opt.textContent = year;
+    select.appendChild(opt);
+  }
+}
+
 function generateRequest(index) {
 const outputEl = document.getElementById(`output-${index}`);
 try {
@@ -148,9 +161,12 @@ clone.querySelector("button[name='remove']").setAttribute('onclick', `removeTrad
 const div = document.createElement('div');
 div.id = `trade-${index}`;
 div.className = 'trade-block';
-div.appendChild(clone);
-document.getElementById('trades').appendChild(div);
-document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
+  div.appendChild(clone);
+  document.getElementById('trades').appendChild(div);
+  const currentYear = new Date().getFullYear();
+  populateYearOptions(`year1-${index}`, currentYear, 3);
+  populateYearOptions(`year2-${index}`, currentYear, 3);
+  document.querySelectorAll(`input[name='side1-${index}']`).forEach(r => {
 r.addEventListener('change', () => syncLegSides(index));
 });
 syncLegSides(index);


### PR DESCRIPTION
## Summary
- populate year `<select>` elements using JavaScript instead of static markup
- add helper `populateYearOptions` in `main.js`
- populate year selects when new trade blocks are added

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6840554acad4832e876e84c5d3fb8e7c