### PR TITLE
Improve layout with trade card headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,10 @@
     body { font-family: 'Inter', sans-serif; }
   </style>
 </head>
-<body class="bg-gray-100 min-h-screen p-6">
-  <div class="max-w-4xl mx-auto">
+<body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
+  <div class="max-w-4xl mx-auto space-y-6">
     <h1 class="text-3xl font-bold mb-6 text-center">LME Trade Request Generator</h1>
-    <div id="trades"></div>
+    <div id="trades" class="space-y-6"></div>
     <div class="flex items-center gap-2 mt-4">
       <button onclick="addTrade()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">Add Trade</button>
       <button onclick="copyAll()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded">Copy All</button>
@@ -23,10 +23,13 @@
   </div>
 
   <template id="trade-template">
-    <div class="bg-white p-6 rounded-lg shadow space-y-4 mb-6">
-      <label class="block font-semibold">Quantity (mt):</label>
-      <input type="number" id="qty-0" class="border border-gray-300 rounded p-2 w-32 mb-3" min="0" step="0.01" />
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="bg-white p-6 rounded-lg shadow-md space-y-4 mb-6 trade-card">
+      <h2 class="text-xl font-semibold trade-title">Trade 1</h2>
+      <div class="flex items-end gap-3 flex-wrap">
+        <label class="font-semibold">Quantity (mt):</label>
+        <input type="number" id="qty-0" class="border border-gray-300 rounded p-2 w-32" min="0" step="0.01" />
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <h2 class="font-semibold">Leg 1</h2>
           <label><input type="radio" name="side1-0" value="buy" checked class="mr-1"/> Buy</label>
@@ -72,7 +75,7 @@
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>
-      <div class="flex items-center gap-2">
+      <div class="flex flex-wrap items-center gap-2">
         <button name="generate" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Generate</button>
         <button name="clear" class="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded">Clear</button>
         <button name="remove" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded">Remove</button>

--- a/main.js
+++ b/main.js
@@ -167,6 +167,8 @@ clone.querySelectorAll('[name]:not([id])').forEach(el => {
 el.name = el.name.replace(/-\d+$/, `-${index}`);
 });
 clone.querySelector("[id^='output-']").id = `output-${index}`;
+ const title = clone.querySelector('.trade-title');
+ if (title) title.textContent = `Trade ${index + 1}`;
 clone.querySelector("button[name='generate']").setAttribute('onclick', `generateRequest(${index})`);
 clone.querySelector("button[name='clear']").setAttribute('onclick', `clearTrade(${index})`);
 clone.querySelector("button[name='remove']").setAttribute('onclick', `removeTrade(${index})`);


### PR DESCRIPTION
## Summary
- update page background and spacing
- add header and quantity layout to trade template
- dynamically update trade titles
- wrap action buttons for better layout

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68405aa3d2a4832e80e844b4c363ac16