### PR TITLE
Add EU date parsing for Fixing Date

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
               <!-- Options populated via JavaScript -->
             </select>
           </label>
-          <label>Fixing Date: <input type="date" id="fixDate-0" class="border border-gray-300 rounded p-2 w-32" placeholder="" /></label>
+           <label>Fixing Date: <input type="text" id="fixDate-0" class="border border-gray-300 rounded p-2 w-32" placeholder="dd-mm-yy" /></label>
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- change fixing date field to free text with dd-mm-yy placeholder
- parse European style dates in JS and validate input
- highlight fixing date when invalid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68406273df58832ea93c1d2e933c4faa