### PR TITLE
Add form-control style utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
     body, input, select, textarea, button {
       font-family: 'Inter', sans-serif;
     }
+    .form-control {
+      border: 1px solid #d1d5db; /* gray-300 */
+      padding: 0.5rem;
+      border-radius: 0.25rem;
+    }
   </style>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
@@ -29,7 +34,7 @@
       <h2 class="text-xl font-semibold trade-title">Trade 1</h2>
       <div class="flex items-end gap-3 flex-wrap">
         <label class="font-semibold">Quantity (mt):</label>
-        <input type="number" id="qty-0" class="border border-gray-300 rounded p-2 w-32" min="0" step="0.01" />
+        <input type="number" id="qty-0" class="form-control w-32" min="0" step="0.01" />
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
@@ -39,14 +44,14 @@
           <label class="block mt-2 mb-1 font-medium">Price Type: <span class="font-semibold text-gray-800">AVG</span></label>
           <input type="hidden" id="type1-0" value="AVG">
           <label>Month:
-            <select id="month1-0" class="border border-gray-300 rounded p-2 w-full">
+            <select id="month1-0" class="form-control w-full">
               <option>January</option><option>February</option><option>March</option><option>April</option>
               <option>May</option><option>June</option><option>July</option><option>August</option>
               <option>September</option><option>October</option><option>November</option><option>December</option>
             </select>
           </label>
           <label>Year:
-            <select id="year1-0" class="border border-gray-300 rounded p-2 w-full">
+            <select id="year1-0" class="form-control w-full">
               <!-- Options populated via JavaScript -->
             </select>
           </label>
@@ -56,24 +61,24 @@
           <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />
           <label>Price Type:
-            <select id="type2-0" class="border border-gray-300 rounded p-2 w-full">
+            <select id="type2-0" class="form-control w-full">
               <option value="AVG">AVG</option>
               <option value="Fix">Fix</option>
             </select>
           </label>
           <label>Month:
-            <select id="month2-0" class="border border-gray-300 rounded p-2 w-full">
+            <select id="month2-0" class="form-control w-full">
               <option>January</option><option>February</option><option>March</option><option>April</option>
               <option>May</option><option>June</option><option>July</option><option>August</option>
               <option>September</option><option>October</option><option>November</option><option>December</option>
             </select>
           </label>
           <label>Year:
-            <select id="year2-0" class="border border-gray-300 rounded p-2 w-full">
+            <select id="year2-0" class="form-control w-full">
               <!-- Options populated via JavaScript -->
             </select>
           </label>
-           <label>Fixing Date: <input type="text" id="fixDate-0" class="border border-gray-300 rounded p-2 w-32" placeholder="dd-mm-yy" /></label>
+           <label>Fixing Date: <input type="text" id="fixDate-0" class="form-control w-32" placeholder="dd-mm-yy" /></label>
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add shared `.form-control` CSS for consistent inputs
- apply `form-control` on all inputs and selects in the trade template

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68406430f520832e8b448f730fb1ff05