### PR TITLE
UI alignment tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   <div class="max-w-4xl mx-auto space-y-6">
     <h1 class="text-3xl font-bold mb-6 text-center">LME Trade Request Generator</h1>
     <div id="trades" class="space-y-6"></div>
-    <div class="flex flex-wrap items-center gap-2 mt-4 justify-center">
+    <div class="flex flex-wrap items-center gap-2 mt-4 justify-start">
       <button onclick="addTrade()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-32">Add Trade</button>
       <button onclick="copyAll()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-32">Copy All</button>
     </div>
@@ -44,14 +44,14 @@
           <label class="block mt-2 mb-1 font-medium">Price Type: <span class="font-semibold text-gray-800">AVG</span></label>
           <input type="hidden" id="type1-0" value="AVG">
           <label>Month:
-            <select id="month1-0" class="form-control w-full">
+            <select id="month1-0" class="form-control w-32">
               <option>January</option><option>February</option><option>March</option><option>April</option>
               <option>May</option><option>June</option><option>July</option><option>August</option>
               <option>September</option><option>October</option><option>November</option><option>December</option>
             </select>
           </label>
           <label>Year:
-            <select id="year1-0" class="form-control w-full">
+            <select id="year1-0" class="form-control w-32">
               <!-- Options populated via JavaScript -->
             </select>
           </label>
@@ -61,25 +61,25 @@
           <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />
           <label>Price Type:
-            <select id="type2-0" class="form-control w-full">
+            <select id="type2-0" class="form-control w-32">
               <option value="AVG">AVG</option>
               <option value="Fix">Fix</option>
             </select>
           </label>
           <label>Month:
-            <select id="month2-0" class="form-control w-full">
+            <select id="month2-0" class="form-control w-32">
               <option>January</option><option>February</option><option>March</option><option>April</option>
               <option>May</option><option>June</option><option>July</option><option>August</option>
               <option>September</option><option>October</option><option>November</option><option>December</option>
             </select>
           </label>
           <label>Year:
-            <select id="year2-0" class="form-control w-full">
+            <select id="year2-0" class="form-control w-32">
               <!-- Options populated via JavaScript -->
             </select>
           </label>
-           <label>Fixing Date: <input type="text" id="fixDate-0" class="form-control w-32" placeholder="dd-mm-yy" /></label>
-          <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
+          <label class="block mt-2">Fixing Date: <input type="text" id="fixDate-0" class="form-control w-32" placeholder="dd-mm-yy" /></label>
+          <label class="block"><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>
       <div class="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary
- align Add Trade button with Generate button on the left
- keep action buttons a consistent width
- shrink price/period selects
- add vertical spacing before Fixing Date in leg 2

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6840669132c0832ea65ff8ed54d66ac8