### PR TITLE
Adjust trade block layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,17 +17,13 @@
       border: 1px solid #d1d5db; /* gray-300 */
       border-radius: 0.25rem;
     }
-    .justify-end { justify-content: flex-end; }
-    @media (min-width: 768px) {
-      .md\:justify-end { justify-content: flex-end; }
-    }
   </style>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
   <div class="max-w-4xl mx-auto space-y-6">
     <h1 class="text-3xl font-bold mb-6 text-center">LME Trade Request Generator</h1>
     <div id="trades" class="space-y-6"></div>
-    <div class="flex flex-wrap items-center gap-2 mt-4 justify-center md:justify-end">
+      <div class="flex flex-wrap items-center gap-2 mt-4 justify-center">
       <button onclick="addTrade()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-32">Add Trade</button>
       <button onclick="copyAll()" class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded w-32">Copy All</button>
     </div>
@@ -48,42 +44,54 @@
           <label><input type="radio" name="side1-0" value="sell" class="mr-1"/> Sell</label><br />
           <label class="block mt-2 mb-1 font-medium">Price Type: <span class="font-semibold text-gray-800">AVG</span></label>
           <input type="hidden" id="type1-0" value="AVG">
-          <label class="block mb-1">Month:</label>
-          <select id="month1-0" class="form-control w-full">
-            <option>January</option><option>February</option><option>March</option><option>April</option>
-            <option>May</option><option>June</option><option>July</option><option>August</option>
-            <option>September</option><option>October</option><option>November</option><option>December</option>
-          </select>
-          <label class="block mb-1">Year:</label>
-          <select id="year1-0" class="form-control w-full">
-            <!-- Options populated via JavaScript -->
-          </select>
+          <div class="flex gap-2">
+            <div>
+              <label class="block mb-1">Month:</label>
+              <select id="month1-0" class="form-control w-28">
+                <option>January</option><option>February</option><option>March</option><option>April</option>
+                <option>May</option><option>June</option><option>July</option><option>August</option>
+                <option>September</option><option>October</option><option>November</option><option>December</option>
+              </select>
+            </div>
+            <div>
+              <label class="block mb-1">Year:</label>
+              <select id="year1-0" class="form-control w-28">
+                <!-- Options populated via JavaScript -->
+              </select>
+            </div>
+          </div>
         </div>
         <div>
           <h2 class="font-semibold">Leg 2</h2>
           <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />
           <label class="block mt-2 mb-1 font-medium">Price Type:</label>
-          <select id="type2-0" class="form-control w-full mb-2">
+          <select id="type2-0" class="form-control w-32 mb-2">
             <option value="AVG">AVG</option>
             <option value="Fix">Fix</option>
           </select>
-          <label class="block mb-1">Month:</label>
-          <select id="month2-0" class="form-control w-full">
-            <option>January</option><option>February</option><option>March</option><option>April</option>
-            <option>May</option><option>June</option><option>July</option><option>August</option>
-            <option>September</option><option>October</option><option>November</option><option>December</option>
-          </select>
-          <label class="block mb-1">Year:</label>
-          <select id="year2-0" class="form-control w-full">
-            <!-- Options populated via JavaScript -->
-          </select>
+          <div class="flex gap-2">
+            <div>
+              <label class="block mb-1">Month:</label>
+              <select id="month2-0" class="form-control w-28">
+                <option>January</option><option>February</option><option>March</option><option>April</option>
+                <option>May</option><option>June</option><option>July</option><option>August</option>
+                <option>September</option><option>October</option><option>November</option><option>December</option>
+              </select>
+            </div>
+            <div>
+              <label class="block mb-1">Year:</label>
+              <select id="year2-0" class="form-control w-28">
+                <!-- Options populated via JavaScript -->
+              </select>
+            </div>
+          </div>
           
            <label>Fixing Date: <input type="text" id="fixDate-0" class="form-control w-32" placeholder="dd-mm-yy" /></label>
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>
         </div>
       </div>
-      <div class="flex flex-wrap items-center gap-2 justify-center md:justify-end">
+      <div class="flex flex-wrap items-center gap-2 justify-center">
         <button name="generate" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded w-32">Generate</button>
         <button name="clear" class="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded w-32">Clear</button>
         <button name="remove" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded w-32">Remove</button>


### PR DESCRIPTION
## Summary
- center button groups again
- keep month/year inline at reduced width
- shrink price type select

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406ca15dac832ea098b86b60113e54