### PR TITLE
Fix date picker position near icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,8 +89,10 @@
           
           <div class="flex items-center gap-2 mr-2">
             <span>Fixing Date:</span>
-            <input type="date" id="fixDate-0" class="hidden" />
-            <button type="button" id="fixBtn-0" class="p-1 border rounded">&#x1F4C5;</button>
+            <div class="relative inline-block">
+              <input type="date" id="fixDate-0" class="absolute inset-0 w-full h-full opacity-0 pointer-events-none" />
+              <button type="button" id="fixBtn-0" class="p-1 border rounded">&#x1F4C5;</button>
+            </div>
             <span id="fixDisplay-0" class="ml-1"></span>
           </div>
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>


### PR DESCRIPTION
## Summary
- keep hidden date input positioned inside button wrapper
- this anchors the browser's date picker near the calendar icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684072a396d8832e812aa24fc8065a82