### PR TITLE
Renumber trade cards automatically

### DIFF
--- a/main.js
+++ b/main.js
@@ -147,7 +147,14 @@ const trade = document.getElementById(`trade-${index}`);
 if (trade) {
 trade.remove();
 updateFinalOutput();
+ renumberTrades();
 }
+}
+
+function renumberTrades() {
+  document.querySelectorAll('.trade-title').forEach((el, i) => {
+    el.textContent = `Trade ${i + 1}`;
+  });
 }
 
 function updateFinalOutput() {
@@ -242,6 +249,7 @@ div.className = 'trade-block';
       fixDisplay.textContent = formatDateEU(new Date(fixInput.value));
     }
   }
+  renumberTrades();
 }
 
 window.onload = () => addTrade();


### PR DESCRIPTION
## Summary
- add `renumberTrades` helper for updating displayed trade numbers
- invoke `renumberTrades` after adding or removing a trade

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_684078a82f74832eb3d81d7c1232b627