### PR TITLE
Remove calendar selector and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ npx http-server -p 8000
 After the server starts, open `http://localhost:8000/index.html` in a modern browser.
 Make sure to visit the full path to `index.html` (not just `/`) because the service worker only caches that file.
 
-## Calendar selector
-
-Use the dropdown at the top of the page to choose between the standard Gregorian calendar and the Chinese lunar calendar. Dates shown in the fixing field will reflect the selected calendar, and calculations such as PPT dates will adapt automatically.
-
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/index.html
+++ b/index.html
@@ -36,13 +36,6 @@
 <body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
   <div class="max-w-4xl mx-auto space-y-6">
     <h1 class="text-3xl font-bold mb-6 text-center">LME Trade Request Generator</h1>
-    <div class="text-center">
-      <label for="calendarType" class="mr-2 font-semibold">Calendar:</label>
-      <select id="calendarType" class="form-control w-40 inline-block">
-        <option value="gregorian">Gregoriano</option>
-        <option value="chinese">Chinês</option>
-      </select>
-    </div>
     <div id="trades" class="space-y-6"></div>
       <div class="flex flex-wrap items-center gap-2 mt-4 justify-center">
       <button onclick="addTrade()" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded w-32">Add Trade</button>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'lme-cache-v3';
+const CACHE_NAME = 'lme-cache-v4';
 
 const FILES_TO_CACHE = [
   'index.html',


### PR DESCRIPTION
## Summary
- remove calendar dropdown from index.html
- drop calendar selector section from README
- bump service worker cache version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68407e2b7f98832e8bbe046d8e6c6d40