### PR TITLE
Simplify date picker handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,20 +17,6 @@
       border: 1px solid #d1d5db; /* gray-300 */
       border-radius: 0.25rem;
     }
-    .hidden-date {
-      position: absolute;
-      top: -5px;
-      left: 5px;
-      width: 100%;
-      height: 100%;
-      opacity: 0;
-      pointer-events: none;
-      -webkit-appearance: none;
-      appearance: none;
-    }
-    .hidden-date::-webkit-calendar-picker-indicator {
-      display: none;
-    }
   </style>
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-gray-100 min-h-screen p-6">
@@ -103,10 +89,7 @@
           
           <div class="flex items-center gap-2 mr-2">
             <span>Fixing Date:</span>
-            <div class="relative inline-block">
-              <input type="text" id="fixDateDisplay-0" class="form-control w-24" placeholder="dd-mm-yy" />
-              <input type="date" id="fixDate-0" class="hidden-date" />
-            </div>
+            <input type="date" id="fixDate-0" class="form-control w-24" />
             <span id="fixDisplay-0" class="ml-1"></span>
           </div>
           <label><input type="checkbox" id="samePpt-0" /> Use AVG PPT Date</label>

--- a/main.js
+++ b/main.js
@@ -219,34 +219,14 @@ div.className = 'trade-block';
   syncLegSides(index);
 
   const fixInput = document.getElementById(`fixDate-${index}`);
-  const fixInputDisplay = document.getElementById(`fixDateDisplay-${index}`);
   const fixDisplay = document.getElementById(`fixDisplay-${index}`);
-  if (fixInput && fixInputDisplay) {
-    const openPicker = () => {
-      if (fixInput.showPicker) {
-        fixInput.showPicker();
-      } else {
-        fixInput.focus();
-        fixInput.click();
-      }
-    };
-    fixInputDisplay.addEventListener('focus', openPicker);
-    fixInputDisplay.addEventListener('click', openPicker);
+  if (fixInput) {
     fixInput.addEventListener('change', () => {
       const formatted = fixInput.value ? formatDate(new Date(fixInput.value)) : '';
-      fixInputDisplay.value = formatted;
       if (fixDisplay) fixDisplay.textContent = formatted;
-    });
-    fixInputDisplay.addEventListener('input', () => {
-      const d = parseDate(fixInputDisplay.value);
-      if (d) {
-        fixInput.valueAsDate = d;
-        if (fixDisplay) fixDisplay.textContent = fixInputDisplay.value;
-      }
     });
     if (fixInput.value) {
       const formatted = formatDate(new Date(fixInput.value));
-      fixInputDisplay.value = formatted;
       if (fixDisplay) fixDisplay.textContent = formatted;
     }
   }


### PR DESCRIPTION
## Summary
- remove custom hidden date overlay
- show native date input directly
- drop CSS for `.hidden-date`
- simplify date handling in `main.js`

## Testing
- `node --check main.js`
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68407fd943cc832e95aeae048c72cd0e