### PR TITLE
Validate quantity input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ npx http-server -p 8000
 After the server starts, open `http://localhost:8000/index.html` in a modern browser.
 Make sure to visit the full path to `index.html` (not just `/`) because the service worker only caches that file.
 
+### Input validation
+
+Enter quantities as finite positive numbers. Values of zero or negative amounts
+will trigger an error message.
+
 ## Building
 
 No build step is required. The repository only contains static files (`index.html`, `main.js`, `manifest.json` and `service-worker.js`). If you modify the code you simply refresh the browser to see the changes.

--- a/main.js
+++ b/main.js
@@ -66,13 +66,19 @@ function generateRequest(index) {
 const outputEl = document.getElementById(`output-${index}`);
 try {
 const qtyInput = document.getElementById(`qty-${index}`);
-const q = parseFloat(qtyInput.value);
-if (!isFinite(q)) {
-qtyInput.classList.add('border-red-500');
-if (outputEl) outputEl.textContent = 'Please enter a valid quantity.';
-qtyInput.focus();
-return;
-}
+  const q = parseFloat(qtyInput.value);
+  if (!isFinite(q)) {
+    qtyInput.classList.add('border-red-500');
+    if (outputEl) outputEl.textContent = 'Please enter a valid quantity.';
+    qtyInput.focus();
+    return;
+  }
+  if (q <= 0) {
+    qtyInput.classList.add('border-red-500');
+    if (outputEl) outputEl.textContent = 'Quantity must be greater than zero.';
+    qtyInput.focus();
+    return;
+  }
 qtyInput.classList.remove('border-red-500');
 const leg1Side = document.querySelector(`input[name='side1-${index}']:checked`).value;
 const leg1Type = document.getElementById(`type1-${index}`)?.value || 'AVG';


### PR DESCRIPTION
## Summary
- enforce that quantity is finite and positive
- show an error if quantity is zero or negative
- document input validation in README

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6840821b2efc832e83bb8ac3333e830b