### PR TITLE
Fix Price Type alignment for Leg 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,11 +67,13 @@
           <h2 class="font-semibold">Leg 2</h2>
           <label><input type="radio" name="side2-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side2-0" value="sell" class="mr-1"/> Sell</label><br />
-          <label class="block mt-2 mb-1 font-medium">Price Type:</label>
-          <select id="type2-0" class="form-control w-32 mb-2">
-            <option value="Fix">Fix</option>
-            <option value="AVG">AVG</option>
-          </select>
+          <div class="flex items-center gap-2 mt-2 mb-2">
+            <label class="font-medium">Price Type:</label>
+            <select id="type2-0" class="form-control w-32">
+              <option value="Fix">Fix</option>
+              <option value="AVG">AVG</option>
+            </select>
+          </div>
           <div class="flex gap-2">
             <div>
               <label class="block mb-1">Month:</label>


### PR DESCRIPTION
## Summary
- keep Price Type label and dropdown together using a flex container

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684087b8d180832eb533e0304e9fa95b