### PR TITLE
Implement Fixed to Fixed with CR2 price type

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,13 @@
           <h2 class="font-semibold">Leg 1</h2>
           <label><input type="radio" name="side1-0" value="buy" checked class="mr-1"/> Buy</label>
           <label><input type="radio" name="side1-0" value="sell" class="mr-1"/> Sell</label><br />
-          <label class="block mt-2 mb-1 font-medium">Price Type: <span class="font-semibold text-gray-800">AVG</span></label>
-          <input type="hidden" id="type1-0" value="AVG">
+          <div class="flex items-center gap-2 mt-2 mb-2">
+            <label class="font-medium">Price Type:</label>
+            <select id="type1-0" class="form-control w-32">
+              <option value="AVG">AVG</option>
+              <option value="Fix">Fix</option>
+            </select>
+          </div>
           <div class="flex gap-2">
             <div>
               <label class="block mb-1">Month:</label>
@@ -71,6 +76,7 @@
             <label class="font-medium">Price Type:</label>
             <select id="type2-0" class="form-control w-32">
               <option value="Fix">Fix</option>
+              <option value="CR2">CR2</option>
               <option value="AVG">AVG</option>
             </select>
           </div>

--- a/main.js
+++ b/main.js
@@ -47,11 +47,11 @@ if (count < 2) date.setDate(date.getDate() + 1);
 return formatDate(date);
 }
 
-function getFixPpt(dateFix, year) {
+function getFixPpt(dateFix) {
   if (!dateFix) throw new Error('Please provide a fixing date.');
   const date = parseDate(dateFix);
   if (!date) throw new Error('Fixing date is invalid.');
-  const holidays = lmeHolidays[year] || [];
+  const holidays = lmeHolidays[date.getFullYear()] || [];
   let count = 0;
   while (count < 2) {
     date.setDate(date.getDate() + 1);
@@ -117,20 +117,29 @@ const useSamePPT = document.getElementById(`samePpt-${index}`).checked;
 const monthIndex = new Date(`${month} 1, ${year}`).getMonth();
 const pptDateAVG = getSecondBusinessDay(year, monthIndex);
 
-let leg1 = `${capitalize(leg1Side)} ${q} mt Al ${leg1Type === 'AVG' ? `AVG ${month} ${year} Flat` : `USD ppt ${pptDateAVG}`}`;
+let leg1;
+if (leg1Type === 'AVG') {
+  leg1 = `${capitalize(leg1Side)} ${q} mt Al AVG ${month} ${year} Flat`;
+} else {
+  const pptFixLeg1 = getFixPpt(dateFix);
+  leg1 = `${capitalize(leg1Side)} ${q} mt Al Fix ppt ${pptFixLeg1}`;
+}
 let leg2;
 if (leg2Type === 'AVG') {
 const month2 = document.getElementById(`month2-${index}`).value;
 const year2 = parseInt(document.getElementById(`year2-${index}`).value);
 leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
-} else {
+} else if (leg2Type === 'Fix') {
   let pptFix;
   if (useSamePPT) {
     pptFix = pptDateAVG;
   } else {
-    pptFix = getFixPpt(dateFix, year);
+    pptFix = getFixPpt(dateFix);
   }
   leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptFix}`;
+} else {
+  const pptFix = getFixPpt(dateFix);
+  leg2 = `${capitalize(leg2Side)} ${q} mt Al CR2 ${dateFix} ppt ${pptFix}`;
 }
 
   const result = `LME Request: ${leg1} and ${leg2} against`;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'lme-cache-v4';
+const CACHE_NAME = 'lme-cache-v5';
 
 const FILES_TO_CACHE = [
   'index.html',


### PR DESCRIPTION
## Summary
- allow price type selection for leg 1
- add new CR2 option for leg 2
- compute prompt date from fixing date when leg 1 uses Fix
- handle CR2 generation in main.js
- bump service worker cache

## Testing
- `node --check main.js`
- `node --check service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68409215f1b0832e93574dfd152bc37e