### PR TITLE
Add C2R price type

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
             <select id="type2-0" class="form-control w-32">
               <option value="Fix">Fix</option>
               <option value="CR2">CR2</option>
+              <option value="C2R">C2R</option>
               <option value="AVG">AVG</option>
             </select>
           </div>

--- a/main.js
+++ b/main.js
@@ -137,6 +137,9 @@ leg2 = `${capitalize(leg2Side)} ${q} mt Al AVG ${month2} ${year2} Flat`;
     pptFix = getFixPpt(dateFix);
   }
   leg2 = `${capitalize(leg2Side)} ${q} mt Al USD ppt ${pptFix}`;
+} else if (leg2Type === 'C2R') {
+  const pptFix = getFixPpt(dateFix);
+  leg2 = `${capitalize(leg2Side)} ${q} mt Al C2R ${dateFix} ppt ${pptFix}`;
 } else {
   const pptFix = getFixPpt(dateFix);
   leg2 = `${capitalize(leg2Side)} ${q} mt Al CR2 ${dateFix} ppt ${pptFix}`;


### PR DESCRIPTION
## Summary
- add `C2R` option to Leg 2 price type dropdown in the HTML
- support `C2R` in `generateRequest`
- handle fixing date validation for `C2R` like other fix types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684096e0bfc4832e8cc26d5c2717bef0