### PR TITLE
Improve service worker cache docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ No build step is required. The repository only contains static files (`index.htm
 
 `service-worker.js` caches the essential files (`index.html`, `main.js`, `calendar-utils.js`, `solarlunar.min.js`, `tailwind.min.css` and the service worker itself) when the app is installed. This lets the app continue working offline after the first visit.
 
-If you update the service worker (for example when the cache name changes), refresh the site in your browser so the new worker can take control and clear the previous cache.
+The worker uses a `CACHE_VERSION` constant to build a cache name (`lme-cache-v<version>`). Increment this value during a release so clients fetch the updated files. The activation step deletes any caches that don't match this name. During installation it also verifies that all core files were cached successfully.
+
+After increasing `CACHE_VERSION`, refresh the site so the new worker can take control and clear the previous cache.
 
 ## Holiday data
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,6 @@
-const CACHE_NAME = 'lme-cache-v5';
+// Update this version when releasing a new build so clients refresh cached files
+const CACHE_VERSION = 5;
+const CACHE_NAME = `lme-cache-v${CACHE_VERSION}`;
 
 const FILES_TO_CACHE = [
   'index.html',
@@ -12,7 +14,14 @@ const FILES_TO_CACHE = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
+    caches.open(CACHE_NAME).then(async cache => {
+      await cache.addAll(FILES_TO_CACHE);
+      // Ensure all required files were cached successfully
+      const results = await Promise.all(FILES_TO_CACHE.map(f => cache.match(f)));
+      if (results.some(r => !r)) {
+        throw new Error('Failed to cache required file');
+      }
+    })
   );
 });
 


### PR DESCRIPTION
## Summary
- document how to bump cache version
- explain worker cache removal and verification
- use `CACHE_VERSION` constant to make versioning explicit
- verify all files are cached during install

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840948e1cdc832ea8b4525ec447a856